### PR TITLE
ensure supporting pkgs are installed

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 # tasks file for fetch-auth-data
 
-#- import_tasks: init.yml
+- import_tasks: init.yml
 - import_tasks: slurp-pubkeys.yml
 - import_tasks: fetch-totp.yml
 - import_tasks: getent-netgroups.yml


### PR DESCRIPTION
openldap-clients and python3-ldap RPMs  (on el8 enrollment_host) are need to run community.general.ldap_search Ansible module